### PR TITLE
Yaml linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,7 @@ jobs:
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root
 
-      - name: Install library
-        run: poetry install --no-interaction
-
       - name: Run Pytest
         run: |
           source .venv/bin/activate
           pytest tests/
-          coverage report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI - Python
 
 on:
   # Trigger the workflow on push or pull request but only for the main branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # This is a CI workflow for running pytests
 
-name: CI
+name: CI - Python
 
 on:
   # Trigger the workflow on push or pull request but only for the main branch
@@ -16,6 +16,7 @@ jobs:
     name: Continuous Integration
     runs-on: ubuntu-latest
     steps:
+      - name: Check out Git repository
       - uses: actions/checkout@v2
 
       - name: Set up Python binary
@@ -26,8 +27,11 @@ jobs:
       - name: Display Python version
         run: echo "The Python version is $(which python)"
 
+      - name: Install Poetry
+        uses: snok/install-poetry@v1.1.1
+
       - name: Install Python dependencies
-        run: pip install pytest
+        run: poetry install
 
       - name: Run Pytest
         run : pytest tests -vvvv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,29 @@ jobs:
         with:
           python-version: '3.9.x'
 
-      - name: Display Python version
-        run: echo "The Python version is $(which python)"
-
       - name: Install Poetry
-        uses: snok/install-poetry@v1.1.1
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
 
-      - name: Install Python dependencies
-        run: poetry install
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v2
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root
+
+      - name: Install library
+        run: poetry install --no-interaction
 
       - name: Run Pytest
-        run : pytest tests -vvvv
+        run: |
+          source .venv/bin/activate
+          pytest tests/
+          coverage report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,4 @@ jobs:
         run: pip install pytest
 
       - name: Run Pytest
-        run : pytest -vvvv
+        run : pytest tests -vvvv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,8 @@ jobs:
       - name: Display Python version
         run: echo "The Python version is $(which python)"
 
+      - name: Install Python dependencies
+        run: pip install pytest
+
       - name: Run Pytest
         run : pytest -vvvv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,4 @@
-# This is a CI workflow for running pytests
-
-name: CI - Python
+name: CI
 
 on:
   # Trigger the workflow on push or pull request but only for the main branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
-      - uses: actions/checkout@v2
+        uses: actions/checkout@v2
 
       - name: Set up Python binary
         uses: actions/setup-python@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+# This is a CI workflow for running pytests
+
+name: CI
+
+on:
+  # Trigger the workflow on push or pull request but only for the main branch
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  CI:
+    name: Continuous Integration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python binary
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.9.x'
+
+      - name: Display Python version
+        run: echo "The Python version is $(which python)"
+
+      - name: Run Pytest
+        run : pytest -vvvv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI - Python
+name: CI
 
 on:
   # Trigger the workflow on push or pull request but only for the main branch
@@ -11,7 +11,7 @@ on:
 
 jobs:
   CI:
-    name: Continuous Integration
+    name: Python Continuous Integration
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,8 +10,8 @@ on:
       - main
 
 jobs:
-  run-linter:
-    name: Run linter
+  run-python-linter:
+    name: Run Python linter
     runs-on: ubuntu-latest
 
     steps:
@@ -37,3 +37,4 @@ jobs:
         #uses: wearerequired/lint-action@v2.0.0
         #with:
           #black : true
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,3 +38,13 @@ jobs:
         #with:
           #black : true
 
+  run-yaml-linter:
+    name: Run Yaml Linter
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Setup yaml-lint
+        uses: ibiqlik/action-yamllint@v3

--- a/poetry.lock
+++ b/poetry.lock
@@ -67,6 +67,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "decorator"
+version = "5.1.1"
+description = "Decorators for Humans"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "flask"
 version = "2.1.2"
 description = "A simple framework for building complex web applications."
@@ -109,7 +117,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.11.3"
+version = "4.11.4"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -243,6 +251,17 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
+name = "self"
+version = "2020.12.3"
+description = "@self decorator makes method return self (jQuery-like chaining)"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+decorator = "*"
+
+[[package]]
 name = "urllib3"
 version = "1.26.9"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -297,7 +316,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "b74c0937c152047a3b2ee11e41a62df969709f276bed01ab1d1299ef64f40cc4"
+content-hash = "ba0e3875243cc135e508ca3278afaefffb580b3950fee6f63692ee0611ab7a6d"
 
 [metadata.files]
 atomicwrites = [
@@ -328,6 +347,10 @@ colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
+decorator = [
+    {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
+    {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
+]
 flask = [
     {file = "Flask-2.1.2-py3-none-any.whl", hash = "sha256:fad5b446feb0d6db6aec0c3184d16a8c1f6c3e464b511649c8918a9be100b4fe"},
     {file = "Flask-2.1.2.tar.gz", hash = "sha256:315ded2ddf8a6281567edb27393010fe3406188bafbfe65a3339d5787d89e477"},
@@ -341,8 +364,8 @@ idna = [
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.11.3-py3-none-any.whl", hash = "sha256:1208431ca90a8cca1a6b8af391bb53c1a2db74e5d1cef6ddced95d4b2062edc6"},
-    {file = "importlib_metadata-4.11.3.tar.gz", hash = "sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539"},
+    {file = "importlib_metadata-4.11.4-py3-none-any.whl", hash = "sha256:c58c8eb8a762858f49e18436ff552e83914778e50e9d2f1660535ffb364552ec"},
+    {file = "importlib_metadata-4.11.4.tar.gz", hash = "sha256:5d26852efe48c0a32b0509ffbc583fda1a2266545a78d104a6f4aff3db17d700"},
 ]
 itsdangerous = [
     {file = "itsdangerous-2.1.2-py3-none-any.whl", hash = "sha256:2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44"},
@@ -421,6 +444,9 @@ pytest = [
 requests = [
     {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
     {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
+]
+self = [
+    {file = "self-2020.12.3.tar.gz", hash = "sha256:a0c408138257e0ba6188f2a7ad80cb3f61c3e48c3f85d1f973a160f6f887dc53"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ xmltodict = "^0.12.0"
 Flask = "^2.0.2"
 cachetools = "^5.0.0"
 gunicorn = "^20.1.0"
+self = "^2020.12.3"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/src/bgg_companion_api.py
+++ b/src/bgg_companion_api.py
@@ -13,7 +13,6 @@ from cachetools import cached, TTLCache
 
 
 class BggCompanionApi(object):
-
     def __init__(self, request_client=None):
         if request_client is None:
             self.request_client = RequestsRetryClient()
@@ -42,7 +41,9 @@ class BggCompanionApi(object):
 
     @cached(cache=TTLCache(maxsize=500, ttl=300))
     def get_board_games(self, ids: tuple[str]) -> list[BoardGame]:
-        string_xml = self.request(f'https://api.geekdo.com/xmlapi2/thing?id={",".join(ids)}')
+        string_xml = self.request(
+            f'https://api.geekdo.com/xmlapi2/thing?id={",".join(ids)}'
+        )
         xml_parse = xmltodict.parse(string_xml)
         if "item" not in xml_parse["items"]:
             raise BoardGameIsNoneError(
@@ -94,7 +95,9 @@ class BggCompanionApi(object):
             id_list.append(game["@objectid"])
         return id_list
 
-    def get_random_game(self, user: str, maxplayers=None, exactplayers=None) -> BoardGame:
+    def get_random_game(
+        self, user: str, maxplayers=None, exactplayers=None
+    ) -> BoardGame:
         ids_list = self.get_users_game_ids(user)
         board_games = self.get_board_games(tuple(ids_list))
         game_filter = GameFilter(maxplayers=maxplayers, exactplayers=exactplayers)
@@ -109,4 +112,3 @@ class BggCompanionApi(object):
 # if __name__ == "__main__":
 #     bgg_companion_api = BggCompanionApi()
 #     print(bgg_companion_api.get_random_game("ewkjfbwkejbgfkwjerbgkjrw"))
-

--- a/src/bgg_companion_api.py
+++ b/src/bgg_companion_api.py
@@ -12,91 +12,101 @@ from typing import OrderedDict
 from cachetools import cached, TTLCache
 
 
-def request(url: str):
-    response = RequestsRetryClient().request(method="GET", url=url)
-    return response.text
+class BggCompanionApi(object):
 
+    def __init__(self, request_client=None):
+        if request_client is None:
+            self.request_client = RequestsRetryClient()
+        else:
+            self.request_client = request_client
 
-@cached(cache=TTLCache(maxsize=500, ttl=300))
-def get_collection(user: str) -> dict:
-    string_xml = request(
-        f"https://boardgamegeek.com/xmlapi2/collection?username={user}"
-    )
-    xml_parse = xmltodict.parse(string_xml)
-    if (
-        "errors" in xml_parse
-        and xml_parse["errors"]["error"]["message"] == "Invalid username specified"
-    ):
-        raise UserIsNoneError(
-            "Invalid username specified.  Please enter a valid https://boardgamegeek.com/ username."
+    def request(self, url: str):
+        response = self.request_client.request(method="GET", url=url)
+        return response.text
+
+    @cached(cache=TTLCache(maxsize=500, ttl=300))
+    def get_collection(self, user: str) -> dict:
+        string_xml = self.request(
+            f"https://boardgamegeek.com/xmlapi2/collection?username={user}"
         )
-    users_game_collection = xml_parse["items"]["item"]
-    return users_game_collection
+        xml_parse = xmltodict.parse(string_xml)
+        if (
+            "errors" in xml_parse
+            and xml_parse["errors"]["error"]["message"] == "Invalid username specified"
+        ):
+            raise UserIsNoneError(
+                "Invalid username specified.  Please enter a valid https://boardgamegeek.com/ username."
+            )
+        users_game_collection = xml_parse["items"]["item"]
+        return users_game_collection
 
+    @cached(cache=TTLCache(maxsize=500, ttl=300))
+    def get_board_games(self, ids: tuple[str]) -> list[BoardGame]:
+        string_xml = self.request(f'https://api.geekdo.com/xmlapi2/thing?id={",".join(ids)}')
+        xml_parse = xmltodict.parse(string_xml)
+        if "item" not in xml_parse["items"]:
+            raise BoardGameIsNoneError(
+                "A board game was passed that does not exist within BoardGameGeek."
+            )
+        items = xml_parse["items"]["item"]
+        board_games = []
+        for item in items:
+            board_games.append(self.to_board_game(item))
+        return board_games
 
-@cached(cache=TTLCache(maxsize=500, ttl=300))
-def get_board_games(ids: tuple[str]) -> list[BoardGame]:
-    string_xml = request(f'https://api.geekdo.com/xmlapi2/thing?id={",".join(ids)}')
-
-    xml_parse = xmltodict.parse(string_xml)
-    if "item" not in xml_parse["items"]:
-        raise BoardGameIsNoneError(
-            "A board game was passed that does not exist within BoardGameGeek."
+    @staticmethod
+    def to_board_game(item: collections.OrderedDict) -> BoardGame:
+        id = item["@id"]
+        type = item["@type"]
+        description = item["description"]
+        minplayers = item["minplayers"]["@value"]
+        maxplayers = item["maxplayers"]["@value"]
+        if "thumbnail" in item and "image" in item:
+            thumbnail = item["thumbnail"]
+            image = item["image"]
+        else:
+            thumbnail = None
+            image = None
+        if isinstance(item["name"], OrderedDict):
+            name = item["name"]["@value"]
+        elif isinstance(item["name"], list):
+            for a_dict in item["name"]:
+                if a_dict["@type"] == "primary":
+                    name = a_dict["@value"]
+                    break
+        else:
+            name = None
+        return BoardGame(
+            id=id,
+            name=name,
+            description=description,
+            type=type,
+            minplayers=minplayers,
+            maxplayers=maxplayers,
+            thumbnail=thumbnail,
+            image=image,
         )
-    items = xml_parse["items"]["item"]
-    board_games = []
-    for item in items:
-        board_games.append(__to_board_game(item))
-    return board_games
+
+    def get_users_game_ids(self, user: str) -> list[str]:
+        users_game_collection = self.get_collection(user)
+        id_list = []
+        for game in users_game_collection:
+            id_list.append(game["@objectid"])
+        return id_list
+
+    def get_random_game(self, user: str, maxplayers=None, exactplayers=None) -> BoardGame:
+        ids_list = self.get_users_game_ids(user)
+        board_games = self.get_board_games(tuple(ids_list))
+        game_filter = GameFilter(maxplayers=maxplayers, exactplayers=exactplayers)
+        filtered_board_games = FilterBoardGames(
+            board_games=board_games, game_filter=game_filter
+        )
+        game = random.choice(filtered_board_games.filter_games())
+        return game
 
 
-def __to_board_game(item: collections.OrderedDict) -> BoardGame:
-    id = item["@id"]
-    type = item["@type"]
-    description = item["description"]
-    minplayers = item["minplayers"]["@value"]
-    maxplayers = item["maxplayers"]["@value"]
-    if "thumbnail" in item and "image" in item:
-        thumbnail = item["thumbnail"]
-        image = item["image"]
-    else:
-        thumbnail = None
-        image = None
-    if isinstance(item["name"], OrderedDict):
-        name = item["name"]["@value"]
-    elif isinstance(item["name"], list):
-        for a_dict in item["name"]:
-            if a_dict["@type"] == "primary":
-                name = a_dict["@value"]
-                break
-    else:
-        name = None
-    return BoardGame(
-        id=id,
-        name=name,
-        description=description,
-        type=type,
-        minplayers=minplayers,
-        maxplayers=maxplayers,
-        thumbnail=thumbnail,
-        image=image,
-    )
+# LEAVE BELOW COMMENTED : Used for development testing
+# if __name__ == "__main__":
+#     bgg_companion_api = BggCompanionApi()
+#     print(bgg_companion_api.get_random_game("ewkjfbwkejbgfkwjerbgkjrw"))
 
-
-def get_users_game_ids(user: str) -> list[str]:
-    users_game_collection = get_collection(user)
-    id_list = []
-    for game in users_game_collection:
-        id_list.append(game["@objectid"])
-    return id_list
-
-
-def get_random_game(user: str, maxplayers=None, exactplayers=None) -> BoardGame:
-    ids_list = get_users_game_ids(user)
-    board_games = get_board_games(tuple(ids_list))
-    game_filter = GameFilter(maxplayers=maxplayers, exactplayers=exactplayers)
-    filtered_board_games = FilterBoardGames(
-        board_games=board_games, game_filter=game_filter
-    )
-    game = random.choice(filtered_board_games.filter_games())
-    return game

--- a/src/models/BoardGame.py
+++ b/src/models/BoardGame.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass(frozen=True)
@@ -9,8 +10,8 @@ class BoardGame:
     description: str
     minplayers: int
     maxplayers: int
-    thumbnail: str
-    image: str
+    thumbnail: Optional[str] = None
+    image: Optional[str] = None
 
     def __post_init__(self):
         object.__setattr__(self, "id", int(self.id))

--- a/tests/models/TestBggCompanionVariables.py
+++ b/tests/models/TestBggCompanionVariables.py
@@ -1,0 +1,1600 @@
+from dataclasses import dataclass
+from collections import OrderedDict
+
+from src.models.BoardGame import BoardGame
+
+
+class TestGetCollectionVariables:
+    user_collection_response = (
+        '<?xml version="1.0" encoding="utf-8" standalone="yes"?><items totalitems="2">\n\t\t<item '
+        'objecttype="thing" objectid="275213" subtype="boardgame" collid="92810535">\n\t<name '
+        'sortindex="1">7 Summits</name>\n\t\t<yearpublished>2021</yearpublished>         '
+        "<image>https://cf.geekdo-images.com/F1wGooL0Vl_zrrSKmHmzYg__original/img"
+        "/E_FId7SFLbBGZ5pwLK-jYDZwvn4=/0x0/filters:format("
+        "jpeg)/pic4875153.jpg</image>\n\t\t<thumbnail>https://cf.geekdo-images.com"
+        "/F1wGooL0Vl_zrrSKmHmzYg__thumb/img/DYU0FXwZedvcvRPRqEGB6G9RApw=/fit-in/200x150/filters"
+        ':strip_icc()/pic4875153.jpg</thumbnail>\n\t\t\t<status own="1" prevowned="0" '
+        'fortrade="0" want="0" '
+        'wanttoplay="0" wanttobuy="0" wishlist="0"  preordered="0" lastmodified="2022-04-04 '
+        '14:36:16" />\n\t  <numplays>0</numplays>                   </item>\n\t\t<item '
+        'objecttype="thing" objectid="68448" subtype="boardgame" collid="87368605">\n\t<name '
+        'sortindex="1">7 Wonders</name>\n\t\t<yearpublished>2010</yearpublished>         '
+        "<image>https://cf.geekdo-images.com/RvFVTEpnbb4NM7k0IF8V7A__original/img"
+        "/JQvRoz0xns9LZII74-ygKGDq_Es=/0x0/filters:format("
+        "jpeg)/pic860217.jpg</image>\n\t\t<thumbnail>https://cf.geekdo-images.com"
+        "/RvFVTEpnbb4NM7k0IF8V7A__thumb/img/ZlG_SRFChObHenw79fAve56_mnk=/fit-in/200x150/filters"
+        ':strip_icc()/pic860217.jpg</thumbnail>\n\t\t\t<status own="1" prevowned="0" fortrade="0" '
+        'want="0" wanttoplay="0" wanttobuy="0" wishlist="0"  preordered="0" '
+        'lastmodified="2021-11-08 12:15:11" />\n\t<numplays>0</numplays>                  '
+        "  </item>\n\n</items> "
+    )
+    expected_get_collection = [
+        OrderedDict(
+            [
+                ("@objecttype", "thing"),
+                ("@objectid", "275213"),
+                ("@subtype", "boardgame"),
+                ("@collid", "92810535"),
+                (
+                    "name",
+                    OrderedDict([("@sortindex", "1"), ("#text", "7 Summits")]),
+                ),
+                ("yearpublished", "2021"),
+                (
+                    "image",
+                    "https://cf.geekdo-images.com/F1wGooL0Vl_zrrSKmHmzYg__original/img/E_FId7SFLbBGZ5pwLK-jYDZwvn4=/0x0/filters:format(jpeg)/pic4875153.jpg",
+                ),
+                (
+                    "thumbnail",
+                    "https://cf.geekdo-images.com/F1wGooL0Vl_zrrSKmHmzYg__thumb/img/DYU0FXwZedvcvRPRqEGB6G9RApw=/fit-in/200x150/filters:strip_icc()/pic4875153.jpg",
+                ),
+                (
+                    "status",
+                    OrderedDict(
+                        [
+                            ("@own", "1"),
+                            ("@prevowned", "0"),
+                            ("@fortrade", "0"),
+                            ("@want", "0"),
+                            ("@wanttoplay", "0"),
+                            ("@wanttobuy", "0"),
+                            ("@wishlist", "0"),
+                            ("@preordered", "0"),
+                            ("@lastmodified", "2022-04-04 14:36:16"),
+                        ]
+                    ),
+                ),
+                ("numplays", "0"),
+            ]
+        ),
+        OrderedDict(
+            [
+                ("@objecttype", "thing"),
+                ("@objectid", "68448"),
+                ("@subtype", "boardgame"),
+                ("@collid", "87368605"),
+                (
+                    "name",
+                    OrderedDict([("@sortindex", "1"), ("#text", "7 Wonders")]),
+                ),
+                ("yearpublished", "2010"),
+                (
+                    "image",
+                    "https://cf.geekdo-images.com/RvFVTEpnbb4NM7k0IF8V7A__original/img/JQvRoz0xns9LZII74-ygKGDq_Es=/0x0/filters:format(jpeg)/pic860217.jpg",
+                ),
+                (
+                    "thumbnail",
+                    "https://cf.geekdo-images.com/RvFVTEpnbb4NM7k0IF8V7A__thumb/img/ZlG_SRFChObHenw79fAve56_mnk=/fit-in/200x150/filters:strip_icc()/pic860217.jpg",
+                ),
+                (
+                    "status",
+                    OrderedDict(
+                        [
+                            ("@own", "1"),
+                            ("@prevowned", "0"),
+                            ("@fortrade", "0"),
+                            ("@want", "0"),
+                            ("@wanttoplay", "0"),
+                            ("@wanttobuy", "0"),
+                            ("@wishlist", "0"),
+                            ("@preordered", "0"),
+                            ("@lastmodified", "2021-11-08 12:15:11"),
+                        ]
+                    ),
+                ),
+                ("numplays", "0"),
+            ]
+        ),
+    ]
+    invalid_user_response = (
+        '<?xml version="1.0" encoding="utf-8" standalone="yes" '
+        "?>\n<errors>\n\t<error>\n\t\t<message>Invalid username "
+        "specified</message>\n\t</error>\n</errors> "
+    )
+
+
+class TestToBoardGameVariables:
+    item_thumbnail_true = OrderedDict(
+        [
+            ("@type", "boardgame"),
+            ("@id", "275213"),
+            (
+                "thumbnail",
+                "https://cf.geekdo-images.com/F1wGooL0Vl_zrrSKmHmzYg__thumb/img/DYU0FXwZedvcvRPRqEGB6G9RApw=/fit-in/200x150/filters:strip_icc()/pic4875153.jpg",
+            ),
+            (
+                "image",
+                "https://cf.geekdo-images.com/F1wGooL0Vl_zrrSKmHmzYg__original/img/E_FId7SFLbBGZ5pwLK-jYDZwvn4=/0x0/filters:format(jpeg)/pic4875153.jpg",
+            ),
+            (
+                "name",
+                OrderedDict(
+                    [
+                        ("@type", "primary"),
+                        ("@sortindex", "1"),
+                        ("@value", "7 Summits"),
+                    ]
+                ),
+            ),
+            (
+                "description",
+                "In 7 Summits, you are a team of world class mountain climbers. Use the dice to your advantage to climb the tallest mountain on each of the seven continents, upgrade your equipment, and advance your skills. Will you be the first to climb them all?&#10;&#10;In this dice drafting game, you'll choose a die to climb its associated mountain; you can stop early to play it safe, or press on for the summit. But watch out &mdash; each time you press on, you run the risk of an avalanche!&#10;&#10;&mdash;description from the publisher&#10;&#10;",
+            ),
+            ("yearpublished", OrderedDict([("@value", "2021")])),
+            ("minplayers", OrderedDict([("@value", "2")])),
+            ("maxplayers", OrderedDict([("@value", "5")])),
+            (
+                "poll",
+                [
+                    OrderedDict(
+                        [
+                            ("@name", "suggested_numplayers"),
+                            ("@title", "User Suggested Number of Players"),
+                            ("@totalvotes", "2"),
+                            (
+                                "results",
+                                [
+                                    OrderedDict(
+                                        [
+                                            ("@numplayers", "1"),
+                                            (
+                                                "result",
+                                                [
+                                                    OrderedDict(
+                                                        [
+                                                            ("@value", "Best"),
+                                                            ("@numvotes", "0"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            (
+                                                                "@value",
+                                                                "Recommended",
+                                                            ),
+                                                            ("@numvotes", "0"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            (
+                                                                "@value",
+                                                                "Not Recommended",
+                                                            ),
+                                                            ("@numvotes", "0"),
+                                                        ]
+                                                    ),
+                                                ],
+                                            ),
+                                        ]
+                                    ),
+                                    OrderedDict(
+                                        [
+                                            ("@numplayers", "2"),
+                                            (
+                                                "result",
+                                                [
+                                                    OrderedDict(
+                                                        [
+                                                            ("@value", "Best"),
+                                                            ("@numvotes", "1"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            (
+                                                                "@value",
+                                                                "Recommended",
+                                                            ),
+                                                            ("@numvotes", "1"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            (
+                                                                "@value",
+                                                                "Not Recommended",
+                                                            ),
+                                                            ("@numvotes", "0"),
+                                                        ]
+                                                    ),
+                                                ],
+                                            ),
+                                        ]
+                                    ),
+                                    OrderedDict(
+                                        [
+                                            ("@numplayers", "3"),
+                                            (
+                                                "result",
+                                                [
+                                                    OrderedDict(
+                                                        [
+                                                            ("@value", "Best"),
+                                                            ("@numvotes", "2"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            (
+                                                                "@value",
+                                                                "Recommended",
+                                                            ),
+                                                            ("@numvotes", "0"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            (
+                                                                "@value",
+                                                                "Not Recommended",
+                                                            ),
+                                                            ("@numvotes", "0"),
+                                                        ]
+                                                    ),
+                                                ],
+                                            ),
+                                        ]
+                                    ),
+                                    OrderedDict(
+                                        [
+                                            ("@numplayers", "4"),
+                                            (
+                                                "result",
+                                                [
+                                                    OrderedDict(
+                                                        [
+                                                            ("@value", "Best"),
+                                                            ("@numvotes", "0"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            (
+                                                                "@value",
+                                                                "Recommended",
+                                                            ),
+                                                            ("@numvotes", "2"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            (
+                                                                "@value",
+                                                                "Not Recommended",
+                                                            ),
+                                                            ("@numvotes", "0"),
+                                                        ]
+                                                    ),
+                                                ],
+                                            ),
+                                        ]
+                                    ),
+                                    OrderedDict(
+                                        [
+                                            ("@numplayers", "5"),
+                                            (
+                                                "result",
+                                                [
+                                                    OrderedDict(
+                                                        [
+                                                            ("@value", "Best"),
+                                                            ("@numvotes", "0"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            (
+                                                                "@value",
+                                                                "Recommended",
+                                                            ),
+                                                            ("@numvotes", "0"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            (
+                                                                "@value",
+                                                                "Not Recommended",
+                                                            ),
+                                                            ("@numvotes", "0"),
+                                                        ]
+                                                    ),
+                                                ],
+                                            ),
+                                        ]
+                                    ),
+                                    OrderedDict(
+                                        [
+                                            ("@numplayers", "5+"),
+                                            (
+                                                "result",
+                                                [
+                                                    OrderedDict(
+                                                        [
+                                                            ("@value", "Best"),
+                                                            ("@numvotes", "0"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            (
+                                                                "@value",
+                                                                "Recommended",
+                                                            ),
+                                                            ("@numvotes", "0"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            (
+                                                                "@value",
+                                                                "Not Recommended",
+                                                            ),
+                                                            ("@numvotes", "0"),
+                                                        ]
+                                                    ),
+                                                ],
+                                            ),
+                                        ]
+                                    ),
+                                ],
+                            ),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@name", "suggested_playerage"),
+                            ("@title", "User Suggested Player Age"),
+                            ("@totalvotes", "2"),
+                            (
+                                "results",
+                                OrderedDict(
+                                    [
+                                        (
+                                            "result",
+                                            [
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "2"),
+                                                        ("@numvotes", "0"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "3"),
+                                                        ("@numvotes", "0"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "4"),
+                                                        ("@numvotes", "0"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "5"),
+                                                        ("@numvotes", "1"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "6"),
+                                                        ("@numvotes", "0"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "8"),
+                                                        ("@numvotes", "1"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "10"),
+                                                        ("@numvotes", "0"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "12"),
+                                                        ("@numvotes", "0"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "14"),
+                                                        ("@numvotes", "0"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "16"),
+                                                        ("@numvotes", "0"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "18"),
+                                                        ("@numvotes", "0"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "21 and up"),
+                                                        ("@numvotes", "0"),
+                                                    ]
+                                                ),
+                                            ],
+                                        )
+                                    ]
+                                ),
+                            ),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@name", "language_dependence"),
+                            ("@title", "Language Dependence"),
+                            ("@totalvotes", "0"),
+                            (
+                                "results",
+                                OrderedDict(
+                                    [
+                                        (
+                                            "result",
+                                            [
+                                                OrderedDict(
+                                                    [
+                                                        ("@level", "296"),
+                                                        (
+                                                            "@value",
+                                                            "No necessary in-game text",
+                                                        ),
+                                                        ("@numvotes", "0"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@level", "297"),
+                                                        (
+                                                            "@value",
+                                                            "Some necessary text - easily memorized or small crib sheet",
+                                                        ),
+                                                        ("@numvotes", "0"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@level", "298"),
+                                                        (
+                                                            "@value",
+                                                            "Moderate in-game text - needs crib sheet or paste ups",
+                                                        ),
+                                                        ("@numvotes", "0"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@level", "299"),
+                                                        (
+                                                            "@value",
+                                                            "Extensive use of text - massive conversion needed to be playable",
+                                                        ),
+                                                        ("@numvotes", "0"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@level", "300"),
+                                                        (
+                                                            "@value",
+                                                            "Unplayable in another language",
+                                                        ),
+                                                        ("@numvotes", "0"),
+                                                    ]
+                                                ),
+                                            ],
+                                        )
+                                    ]
+                                ),
+                            ),
+                        ]
+                    ),
+                ],
+            ),
+            ("playingtime", OrderedDict([("@value", "40")])),
+            ("minplaytime", OrderedDict([("@value", "30")])),
+            ("maxplaytime", OrderedDict([("@value", "40")])),
+            ("minage", OrderedDict([("@value", "12")])),
+            (
+                "link",
+                [
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamecategory"),
+                            ("@id", "1017"),
+                            ("@value", "Dice"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamecategory"),
+                            ("@id", "1031"),
+                            ("@value", "Racing"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamemechanic"),
+                            ("@id", "2072"),
+                            ("@value", "Dice Rolling"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamemechanic"),
+                            ("@id", "2856"),
+                            ("@value", "Die Icon Resolution"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamemechanic"),
+                            ("@id", "2041"),
+                            ("@value", "Open Drafting"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamemechanic"),
+                            ("@id", "2661"),
+                            ("@value", "Push Your Luck"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamemechanic"),
+                            ("@id", "2939"),
+                            ("@value", "Track Movement"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamemechanic"),
+                            ("@id", "2828"),
+                            ("@value", "Turn Order: Progressive"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamefamily"),
+                            ("@id", "4705"),
+                            (
+                                "@value",
+                                "Organizations: The Game Artisans of Canada",
+                            ),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamefamily"),
+                            ("@id", "6043"),
+                            ("@value", "Sports: Mountain Climbing"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameexpansion"),
+                            ("@id", "331057"),
+                            ("@value", "7 Summits: Launch Promos"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamedesigner"),
+                            ("@id", "88370"),
+                            ("@value", "Adrian Adamescu"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamedesigner"),
+                            ("@id", "67502"),
+                            ("@value", "Daryl Andrews"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameartist"),
+                            ("@id", "81450"),
+                            ("@value", "Megan Cheever"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameartist"),
+                            ("@id", "28024"),
+                            ("@value", "Kwanchai Moriya"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameartist"),
+                            ("@id", "127486"),
+                            ("@value", "Sean Seal"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamepublisher"),
+                            ("@id", "38131"),
+                            ("@value", "Deep Water Games"),
+                        ]
+                    ),
+                ],
+            ),
+        ]
+    )
+    boardgame_thumbnail_true = BoardGame(
+        id=275213,
+        name="7 Summits",
+        type="boardgame",
+        description="In 7 Summits, you are a team of world class mountain climbers. Use the dice to your advantage to climb the tallest mountain on each of the seven continents, upgrade your equipment, and advance your skills. Will you be the first to climb them all?&#10;&#10;In this dice drafting game, you'll choose a die to climb its associated mountain; you can stop early to play it safe, or press on for the summit. But watch out &mdash; each time you press on, you run the risk of an avalanche!&#10;&#10;&mdash;description from the publisher&#10;&#10;",
+        minplayers=2,
+        maxplayers=5,
+        thumbnail="https://cf.geekdo-images.com/F1wGooL0Vl_zrrSKmHmzYg__thumb/img/DYU0FXwZedvcvRPRqEGB6G9RApw=/fit-in/200x150/filters:strip_icc()/pic4875153.jpg",
+        image="https://cf.geekdo-images.com/F1wGooL0Vl_zrrSKmHmzYg__original/img/E_FId7SFLbBGZ5pwLK-jYDZwvn4=/0x0/filters:format(jpeg)/pic4875153.jpg",
+    )
+    item_thumbnail_false = OrderedDict(
+        [
+            ("@type", "boardgame"),
+            ("@id", "68448"),
+            (
+                "name",
+                [
+                    OrderedDict(
+                        [
+                            ("@type", "primary"),
+                            ("@sortindex", "1"),
+                            ("@value", "7 Wonders"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "alternate"),
+                            ("@sortindex", "1"),
+                            ("@value", "7 csoda"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "alternate"),
+                            ("@sortindex", "1"),
+                            ("@value", "7 Cudów Świata"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "alternate"),
+                            ("@sortindex", "1"),
+                            ("@value", "7 divů světa"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "alternate"),
+                            ("@sortindex", "1"),
+                            ("@value", "7 Wonders"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "alternate"),
+                            ("@sortindex", "1"),
+                            ("@value", "7 чудес"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "alternate"),
+                            ("@sortindex", "1"),
+                            ("@value", "7 สิ่งมหัศจรรย์"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "alternate"),
+                            ("@sortindex", "1"),
+                            ("@value", "7 원더스"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "alternate"),
+                            ("@sortindex", "1"),
+                            ("@value", "Τα 7 θαύματα του κόσμου"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "alternate"),
+                            ("@sortindex", "1"),
+                            ("@value", "七大奇蹟"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "alternate"),
+                            ("@sortindex", "1"),
+                            ("@value", "七大奇迹"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "alternate"),
+                            ("@sortindex", "1"),
+                            ("@value", "世界の七不思議"),
+                        ]
+                    ),
+                ],
+            ),
+            (
+                "description",
+                "You are the leader of one of the 7 great cities of the Ancient World. Gather resources, develop commercial routes, and affirm your military supremacy. Build your city and erect an architectural wonder which will transcend future times.&#10;&#10;7 Wonders lasts three ages. In each age, players receive seven cards from a particular deck, choose one of those cards, then pass the remainder to an adjacent player. Players reveal their cards simultaneously, paying resources if needed or collecting resources or interacting with other players in various ways. (Players have individual boards with special powers on which to organize their cards, and the boards are double-sided). Each player then chooses another card from the deck they were passed, and the process repeats until players have six cards in play from that age. After three ages, the game ends.&#10;&#10;In essence, 7 Wonders is a card development game. Some cards have immediate effects, while others provide bonuses or upgrades later in the game. Some cards provide discounts on future purchases. Some provide military strength to overpower your neighbors and others give nothing but victory points. Each card is played immediately after being drafted, so you'll know which cards your neighbor is receiving and how her choices might affect what you've already built up. Cards are passed left-right-left over the three ages, so you need to keep an eye on the neighbors in both directions.&#10;&#10;Though the box of earlier editions is listed as being for 3&ndash;7 players, there is an official 2-player variant included in the instructions.&#10;&#10;",
+            ),
+            ("yearpublished", OrderedDict([("@value", "2010")])),
+            ("minplayers", OrderedDict([("@value", "2")])),
+            ("maxplayers", OrderedDict([("@value", "7")])),
+            (
+                "poll",
+                [
+                    OrderedDict(
+                        [
+                            ("@name", "suggested_numplayers"),
+                            ("@title", "User Suggested Number of Players"),
+                            ("@totalvotes", "2201"),
+                            (
+                                "results",
+                                [
+                                    OrderedDict(
+                                        [
+                                            ("@numplayers", "1"),
+                                            (
+                                                "result",
+                                                [
+                                                    OrderedDict(
+                                                        [
+                                                            ("@value", "Best"),
+                                                            ("@numvotes", "4"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            ("@value", "Recommended"),
+                                                            ("@numvotes", "15"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            (
+                                                                "@value",
+                                                                "Not Recommended",
+                                                            ),
+                                                            ("@numvotes", "1329"),
+                                                        ]
+                                                    ),
+                                                ],
+                                            ),
+                                        ]
+                                    ),
+                                    OrderedDict(
+                                        [
+                                            ("@numplayers", "2"),
+                                            (
+                                                "result",
+                                                [
+                                                    OrderedDict(
+                                                        [
+                                                            ("@value", "Best"),
+                                                            ("@numvotes", "117"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            ("@value", "Recommended"),
+                                                            ("@numvotes", "371"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            (
+                                                                "@value",
+                                                                "Not Recommended",
+                                                            ),
+                                                            ("@numvotes", "1130"),
+                                                        ]
+                                                    ),
+                                                ],
+                                            ),
+                                        ]
+                                    ),
+                                    OrderedDict(
+                                        [
+                                            ("@numplayers", "3"),
+                                            (
+                                                "result",
+                                                [
+                                                    OrderedDict(
+                                                        [
+                                                            ("@value", "Best"),
+                                                            ("@numvotes", "475"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            ("@value", "Recommended"),
+                                                            ("@numvotes", "1154"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            (
+                                                                "@value",
+                                                                "Not Recommended",
+                                                            ),
+                                                            ("@numvotes", "199"),
+                                                        ]
+                                                    ),
+                                                ],
+                                            ),
+                                        ]
+                                    ),
+                                    OrderedDict(
+                                        [
+                                            ("@numplayers", "4"),
+                                            (
+                                                "result",
+                                                [
+                                                    OrderedDict(
+                                                        [
+                                                            ("@value", "Best"),
+                                                            ("@numvotes", "1167"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            ("@value", "Recommended"),
+                                                            ("@numvotes", "739"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            (
+                                                                "@value",
+                                                                "Not Recommended",
+                                                            ),
+                                                            ("@numvotes", "41"),
+                                                        ]
+                                                    ),
+                                                ],
+                                            ),
+                                        ]
+                                    ),
+                                    OrderedDict(
+                                        [
+                                            ("@numplayers", "5"),
+                                            (
+                                                "result",
+                                                [
+                                                    OrderedDict(
+                                                        [
+                                                            ("@value", "Best"),
+                                                            ("@numvotes", "1017"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            ("@value", "Recommended"),
+                                                            ("@numvotes", "816"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            (
+                                                                "@value",
+                                                                "Not Recommended",
+                                                            ),
+                                                            ("@numvotes", "57"),
+                                                        ]
+                                                    ),
+                                                ],
+                                            ),
+                                        ]
+                                    ),
+                                    OrderedDict(
+                                        [
+                                            ("@numplayers", "6"),
+                                            (
+                                                "result",
+                                                [
+                                                    OrderedDict(
+                                                        [
+                                                            ("@value", "Best"),
+                                                            ("@numvotes", "458"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            ("@value", "Recommended"),
+                                                            ("@numvotes", "1123"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            (
+                                                                "@value",
+                                                                "Not Recommended",
+                                                            ),
+                                                            ("@numvotes", "164"),
+                                                        ]
+                                                    ),
+                                                ],
+                                            ),
+                                        ]
+                                    ),
+                                    OrderedDict(
+                                        [
+                                            ("@numplayers", "7"),
+                                            (
+                                                "result",
+                                                [
+                                                    OrderedDict(
+                                                        [
+                                                            ("@value", "Best"),
+                                                            ("@numvotes", "383"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            ("@value", "Recommended"),
+                                                            ("@numvotes", "1047"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            (
+                                                                "@value",
+                                                                "Not Recommended",
+                                                            ),
+                                                            ("@numvotes", "290"),
+                                                        ]
+                                                    ),
+                                                ],
+                                            ),
+                                        ]
+                                    ),
+                                    OrderedDict(
+                                        [
+                                            ("@numplayers", "7+"),
+                                            (
+                                                "result",
+                                                [
+                                                    OrderedDict(
+                                                        [
+                                                            ("@value", "Best"),
+                                                            ("@numvotes", "30"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            ("@value", "Recommended"),
+                                                            ("@numvotes", "101"),
+                                                        ]
+                                                    ),
+                                                    OrderedDict(
+                                                        [
+                                                            (
+                                                                "@value",
+                                                                "Not Recommended",
+                                                            ),
+                                                            ("@numvotes", "895"),
+                                                        ]
+                                                    ),
+                                                ],
+                                            ),
+                                        ]
+                                    ),
+                                ],
+                            ),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@name", "suggested_playerage"),
+                            ("@title", "User Suggested Player Age"),
+                            ("@totalvotes", "504"),
+                            (
+                                "results",
+                                OrderedDict(
+                                    [
+                                        (
+                                            "result",
+                                            [
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "2"),
+                                                        ("@numvotes", "0"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "3"),
+                                                        ("@numvotes", "0"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "4"),
+                                                        ("@numvotes", "1"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "5"),
+                                                        ("@numvotes", "1"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "6"),
+                                                        ("@numvotes", "19"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "8"),
+                                                        ("@numvotes", "144"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "10"),
+                                                        ("@numvotes", "197"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "12"),
+                                                        ("@numvotes", "117"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "14"),
+                                                        ("@numvotes", "21"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "16"),
+                                                        ("@numvotes", "3"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "18"),
+                                                        ("@numvotes", "1"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@value", "21 and up"),
+                                                        ("@numvotes", "0"),
+                                                    ]
+                                                ),
+                                            ],
+                                        )
+                                    ]
+                                ),
+                            ),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@name", "language_dependence"),
+                            ("@title", "Language Dependence"),
+                            ("@totalvotes", "400"),
+                            (
+                                "results",
+                                OrderedDict(
+                                    [
+                                        (
+                                            "result",
+                                            [
+                                                OrderedDict(
+                                                    [
+                                                        ("@level", "336"),
+                                                        (
+                                                            "@value",
+                                                            "No necessary in-game text",
+                                                        ),
+                                                        ("@numvotes", "306"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@level", "337"),
+                                                        (
+                                                            "@value",
+                                                            "Some necessary text - easily memorized or small crib sheet",
+                                                        ),
+                                                        ("@numvotes", "89"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@level", "338"),
+                                                        (
+                                                            "@value",
+                                                            "Moderate in-game text - needs crib sheet or paste ups",
+                                                        ),
+                                                        ("@numvotes", "4"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@level", "339"),
+                                                        (
+                                                            "@value",
+                                                            "Extensive use of text - massive conversion needed to be playable",
+                                                        ),
+                                                        ("@numvotes", "1"),
+                                                    ]
+                                                ),
+                                                OrderedDict(
+                                                    [
+                                                        ("@level", "340"),
+                                                        (
+                                                            "@value",
+                                                            "Unplayable in another language",
+                                                        ),
+                                                        ("@numvotes", "0"),
+                                                    ]
+                                                ),
+                                            ],
+                                        )
+                                    ]
+                                ),
+                            ),
+                        ]
+                    ),
+                ],
+            ),
+            ("playingtime", OrderedDict([("@value", "30")])),
+            ("minplaytime", OrderedDict([("@value", "30")])),
+            ("maxplaytime", OrderedDict([("@value", "30")])),
+            ("minage", OrderedDict([("@value", "10")])),
+            (
+                "link",
+                [
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamecategory"),
+                            ("@id", "1050"),
+                            ("@value", "Ancient"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamecategory"),
+                            ("@id", "1002"),
+                            ("@value", "Card Game"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamecategory"),
+                            ("@id", "1029"),
+                            ("@value", "City Building"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamecategory"),
+                            ("@id", "1015"),
+                            ("@value", "Civilization"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamecategory"),
+                            ("@id", "1021"),
+                            ("@value", "Economic"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamemechanic"),
+                            ("@id", "2984"),
+                            ("@value", "Closed Drafting"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamemechanic"),
+                            ("@id", "2040"),
+                            ("@value", "Hand Management"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamemechanic"),
+                            ("@id", "2004"),
+                            ("@value", "Set Collection"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamemechanic"),
+                            ("@id", "2020"),
+                            ("@value", "Simultaneous Action Selection"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamemechanic"),
+                            ("@id", "2015"),
+                            ("@value", "Variable Player Powers"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamefamily"),
+                            ("@id", "27524"),
+                            ("@value", "Ancient: Babylon"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamefamily"),
+                            ("@id", "72535"),
+                            ("@value", "Ancient: Egypt"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamefamily"),
+                            ("@id", "52373"),
+                            ("@value", "Ancient: Greece"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamefamily"),
+                            ("@id", "70360"),
+                            ("@value", "Digital Implementations: Board Game Arena"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamefamily"),
+                            ("@id", "17552"),
+                            ("@value", "Game: 7 Wonders"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamefamily"),
+                            ("@id", "71181"),
+                            ("@value", "Mechanism: Artificial Player"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamefamily"),
+                            ("@id", "27646"),
+                            ("@value", "Mechanism: Tableau Building"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameexpansion"),
+                            ("@id", "247315"),
+                            ("@value", "7 Wonders: Armada"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameexpansion"),
+                            ("@id", "154638"),
+                            ("@value", "7 Wonders: Babel"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameexpansion"),
+                            ("@id", "110308"),
+                            ("@value", "7 Wonders: Catan"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameexpansion"),
+                            ("@id", "111661"),
+                            ("@value", "7 Wonders: Cities"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameexpansion"),
+                            ("@id", "92539"),
+                            ("@value", "7 Wonders: Leaders"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameexpansion"),
+                            ("@id", "83445"),
+                            ("@value", "7 Wonders: Manneken Pis"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameexpansion"),
+                            ("@id", "133993"),
+                            ("@value", "7 Wonders: Wonder Pack"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameexpansion"),
+                            ("@id", "164649"),
+                            ("@value", "Collection (fan expansion for 7 Wonders)"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameexpansion"),
+                            ("@id", "140098"),
+                            ("@value", "Empires (fan expansion for 7 Wonders)"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameexpansion"),
+                            ("@id", "138187"),
+                            ("@value", "Game Wonders (fan expansion for 7 Wonders)"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameexpansion"),
+                            ("@id", "134849"),
+                            ("@value", "Lost Wonders (fan expansion for 7 Wonders)"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameexpansion"),
+                            ("@id", "329310"),
+                            ("@value", "Modern Wonders (fan expansion for 7 Wonders)"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameexpansion"),
+                            ("@id", "131947"),
+                            ("@value", "More Wonders... (fan expansion for 7 Wonders)"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameexpansion"),
+                            ("@id", "132146"),
+                            ("@value", "Myths (fan expansion for 7 Wonders)"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameexpansion"),
+                            ("@id", "164648"),
+                            ("@value", "Ruins (fan expansion for 7 Wonders)"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameexpansion"),
+                            ("@id", "164647"),
+                            ("@value", "Sailors (fan expansion for 7 Wonders)"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameimplementation"),
+                            ("@id", "316377"),
+                            ("@value", "7 Wonders (Second Edition)"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameimplementation"),
+                            ("@id", "173346"),
+                            ("@value", "7 Wonders Duel"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameimplementation"),
+                            ("@id", "346703"),
+                            ("@value", "7 Wonders: Architects"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamedesigner"),
+                            ("@id", "9714"),
+                            ("@value", "Antoine Bauza"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameartist"),
+                            ("@id", "62528"),
+                            ("@value", "Dimitri Chappuis"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameartist"),
+                            ("@id", "12016"),
+                            ("@value", "Miguel Coimbra"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameartist"),
+                            ("@id", "100254"),
+                            ("@value", "Etienne Hebinger"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgameartist"),
+                            ("@id", "89045"),
+                            ("@value", "Cyril Nouvel"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamepublisher"),
+                            ("@id", "4384"),
+                            ("@value", "Repos Production"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamepublisher"),
+                            ("@id", "23043"),
+                            ("@value", "ADC Blackfire Entertainment"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamepublisher"),
+                            ("@id", "157"),
+                            ("@value", "Asmodee"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamepublisher"),
+                            ("@id", "15889"),
+                            ("@value", "Asterion Press"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamepublisher"),
+                            ("@id", "15605"),
+                            ("@value", "Galápagos Jogos"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamepublisher"),
+                            ("@id", "8820"),
+                            ("@value", "Gém Klub Kft."),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamepublisher"),
+                            ("@id", "1391"),
+                            ("@value", "Hobby Japan"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamepublisher"),
+                            ("@id", "6214"),
+                            ("@value", "Kaissa Chess & Games"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamepublisher"),
+                            ("@id", "8291"),
+                            ("@value", "Korea Boardgames Co., Ltd."),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamepublisher"),
+                            ("@id", "3218"),
+                            ("@value", "Lautapelit.fi"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamepublisher"),
+                            ("@id", "9325"),
+                            ("@value", "Lifestyle Boardgames Ltd"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamepublisher"),
+                            ("@id", "32395"),
+                            ("@value", "NeoTroy Games"),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamepublisher"),
+                            ("@id", "7466"),
+                            ("@value", "Rebel Sp. z o.o."),
+                        ]
+                    ),
+                    OrderedDict(
+                        [
+                            ("@type", "boardgamepublisher"),
+                            ("@id", "33998"),
+                            ("@value", "Siam Board Games"),
+                        ]
+                    ),
+                ],
+            ),
+        ]
+    )
+    boardgame_thumbnail_false = BoardGame(
+        id=68448,
+        name="7 Wonders",
+        type="boardgame",
+        description="You are the leader of one of the 7 great cities of the Ancient World. Gather resources, develop commercial routes, and affirm your military supremacy. Build your city and erect an architectural wonder which will transcend future times.&#10;&#10;7 Wonders lasts three ages. In each age, players receive seven cards from a particular deck, choose one of those cards, then pass the remainder to an adjacent player. Players reveal their cards simultaneously, paying resources if needed or collecting resources or interacting with other players in various ways. (Players have individual boards with special powers on which to organize their cards, and the boards are double-sided). Each player then chooses another card from the deck they were passed, and the process repeats until players have six cards in play from that age. After three ages, the game ends.&#10;&#10;In essence, 7 Wonders is a card development game. Some cards have immediate effects, while others provide bonuses or upgrades later in the game. Some cards provide discounts on future purchases. Some provide military strength to overpower your neighbors and others give nothing but victory points. Each card is played immediately after being drafted, so you'll know which cards your neighbor is receiving and how her choices might affect what you've already built up. Cards are passed left-right-left over the three ages, so you need to keep an eye on the neighbors in both directions.&#10;&#10;Though the box of earlier editions is listed as being for 3&ndash;7 players, there is an official 2-player variant included in the instructions.&#10;&#10;",
+        minplayers=2,
+        maxplayers=7,
+        thumbnail=None,
+        image=None,
+    )

--- a/tests/test_bgg_companion.py
+++ b/tests/test_bgg_companion.py
@@ -53,7 +53,7 @@ class TestToBoardGame:
         test_variables = TestToBoardGameVariables()
 
         bgg_companion_api = BggCompanionApi()
-        test_item = test_variables.item_thumbnail_true
+        test_item = test_variables.item_thumbnail_false
         test_boardgame = test_variables.boardgame_thumbnail_true
 
         actual_to_board_game = bgg_companion_api.to_board_game(test_item)

--- a/tests/test_bgg_companion.py
+++ b/tests/test_bgg_companion.py
@@ -32,6 +32,7 @@ class TestGetCollection(unittest.TestCase):
     @staticmethod
     def test_exception_for_invalid_user():
         """Testing the get_collection function for requesting a BGG collection of an invalid user"""
+
     test_variables = TestGetCollectionVariables()
 
     mock_response = unittest.mock.Mock(spec=["text"])

--- a/tests/test_bgg_companion.py
+++ b/tests/test_bgg_companion.py
@@ -53,7 +53,7 @@ class TestToBoardGame:
         test_variables = TestToBoardGameVariables()
 
         bgg_companion_api = BggCompanionApi()
-        test_item = test_variables.item_thumbnail_false
+        test_item = test_variables.item_thumbnail_true
         test_boardgame = test_variables.boardgame_thumbnail_true
 
         actual_to_board_game = bgg_companion_api.to_board_game(test_item)

--- a/tests/test_bgg_companion.py
+++ b/tests/test_bgg_companion.py
@@ -1,5 +1,106 @@
-from bgg_companion import __version__
+import unittest.mock
+import pytest
+
+from src.bgg_companion_api import BggCompanionApi
+from src.exceptions import UserIsNoneError
+from tests.models.TestBggCompanionVariables import (
+    TestGetCollectionVariables,
+    TestToBoardGameVariables,
+)
 
 
-def test_version():
-    assert __version__ == "0.1.0"
+# Tests are ran with poetry run pytest -vvvv or poetry run pytest -k test_function_name
+
+
+class TestGetCollection(unittest.TestCase):
+    @staticmethod
+    def test_get_request_for_users_collection():
+        """Testing the get_collection function for requesting a BGG collection of a valid user"""
+        test_variables = TestGetCollectionVariables()
+
+        mock_response = unittest.mock.Mock(spec=["text"])
+        mock_response.text = test_variables.user_collection_response
+        mock_request_client = unittest.mock.Mock(spec=["request"])
+        mock_request_client.request.return_value = mock_response
+
+        bgg_companion_api = BggCompanionApi(mock_request_client)
+        actual_get_collection = bgg_companion_api.get_collection("test_user")
+        expected_get_collection = test_variables.expected_get_collection
+
+        assert actual_get_collection == expected_get_collection
+
+    @staticmethod
+    def test_exception_for_invalid_user():
+        """Testing the get_collection function for requesting a BGG collection of an invalid user"""
+    test_variables = TestGetCollectionVariables()
+
+    mock_response = unittest.mock.Mock(spec=["text"])
+    mock_response.text = test_variables.invalid_user_response
+    mock_request_client = unittest.mock.Mock(spec=["request"])
+    mock_request_client.request.return_value = mock_response
+
+    bgg_companion_api = BggCompanionApi(mock_request_client)
+    with pytest.raises(UserIsNoneError):
+        bgg_companion_api.get_collection("test__invalid_user")
+
+
+class TestToBoardGame:
+    @staticmethod
+    def test_item_mapping_to_boardgame_THUMBNAIL_TRUE():
+        """Testing the to_board_game function for mapping a given item that has a thumbnail to the BoardGame data
+        class"""
+        test_variables = TestToBoardGameVariables()
+
+        bgg_companion_api = BggCompanionApi()
+        test_item = test_variables.item_thumbnail_true
+        test_boardgame = test_variables.boardgame_thumbnail_true
+
+        actual_to_board_game = bgg_companion_api.to_board_game(test_item)
+        expected_to_board_game = test_boardgame
+
+        assert actual_to_board_game == expected_to_board_game
+
+    @staticmethod
+    def test_item_mapping_to_boardgame_THUMBNAIL_FALSE():
+        """Testing the to_board_game function for mapping a given item that doesn't have a thumbnail to the BoardGame
+        data class"""
+        test_variables = TestToBoardGameVariables()
+
+        bgg_companion_api = BggCompanionApi()
+        test_item = test_variables.item_thumbnail_false
+        test_boardgame = test_variables.boardgame_thumbnail_false
+
+        actual_to_board_game = bgg_companion_api.to_board_game(test_item)
+        expected_to_board_game = test_boardgame
+
+        assert actual_to_board_game == expected_to_board_game
+
+    @staticmethod
+    def test_item_mapping_to_boardgame_NAME_IS_DICT():
+        """Testing the to_board_game function for mapping a given item where the ["name"] value is a type OrderedDict
+        to the BoardGame data class"""
+        test_variables = TestToBoardGameVariables()
+
+        bgg_companion_api = BggCompanionApi()
+        test_item = test_variables.item_thumbnail_true
+        test_boardgame = test_variables.boardgame_thumbnail_true
+
+        actual_to_board_game = bgg_companion_api.to_board_game(test_item)
+        expected_to_board_game = test_boardgame
+
+        assert actual_to_board_game == expected_to_board_game
+
+    @staticmethod
+    def test_item_mapping_to_boardgame_NAME_IS_LIST():
+        """Testing the to_board_game function for mapping a given item where the ["name"] value is a type list to the
+        BoardGame data class"""
+        test_variables = TestToBoardGameVariables()
+
+        bgg_companion_api = BggCompanionApi()
+        test_item = test_variables.item_thumbnail_false
+        test_boardgame = test_variables.boardgame_thumbnail_false
+
+        actual_to_board_game = bgg_companion_api.to_board_game(test_item)
+        expected_to_board_game = test_boardgame
+
+        assert actual_to_board_game == expected_to_board_game


### PR DESCRIPTION
In the PR https://github.com/JDGiardino/BGG-Companion/pull/23 I ran into an issue where I accidentally broke the yaml file for a workflow and I didn't know what was wrong for awhile.  This PR adds a new job on the Linter GH workflow for yaml files so that a GH action runs on all PRs to fix formatting within yamls.  This comes from the documentation here https://github.com/marketplace/actions/yaml-lint.  

I will test that the error I made in PR 23 would be caught by the linter in this PR.