### PR TITLE
Games include their release year

### DIFF
--- a/src/bgg_companion_api.py
+++ b/src/bgg_companion_api.py
@@ -69,6 +69,7 @@ class BggCompanionApi(object):
         description = item["description"]
         minplayers = item["minplayers"]["@value"]
         maxplayers = item["maxplayers"]["@value"]
+        yearpublished = item["yearpublished"]["@value"]
         if "thumbnail" in item and "image" in item:
             thumbnail = item["thumbnail"]
             image = item["image"]
@@ -91,6 +92,7 @@ class BggCompanionApi(object):
             type=type,
             minplayers=minplayers,
             maxplayers=maxplayers,
+            yearpublished=yearpublished,
             thumbnail=thumbnail,
             image=image,
         )

--- a/src/models/BoardGame.py
+++ b/src/models/BoardGame.py
@@ -10,6 +10,7 @@ class BoardGame:
     description: str
     minplayers: int
     maxplayers: int
+    yearpublished: int
     thumbnail: Optional[str] = None
     image: Optional[str] = None
 
@@ -17,4 +18,5 @@ class BoardGame:
         object.__setattr__(self, "id", int(self.id))
         object.__setattr__(self, "maxplayers", int(self.maxplayers))
         object.__setattr__(self, "minplayers", int(self.minplayers))
+        object.__setattr__(self, "yearpublished", int(self.yearpublished))
         # This bypasses frozen=true by modifying the object class which all objects inherent from including dataclasses

--- a/static/app.js
+++ b/static/app.js
@@ -13,6 +13,7 @@ async function get_random_game() {
                 const game = await response.json();
                 const game_field = document.getElementById("game-name");
                 game_field.innerHTML += game.name.link("https://boardgamegeek.com/boardgame/" + game.id);
+                game_field.innerHTML += `  (${game.yearpublished})`;
 
                 const img = document.getElementById("game-thumbnail");
                 img.src = game.image;

--- a/tests/models/TestBggCompanionData.py
+++ b/tests/models/TestBggCompanionData.py
@@ -72,6 +72,7 @@ class TestGetBoardGamesData:
             description="StarWars:Rebellion is a board game of epic conflict.",
             minplayers=2,
             maxplayers=4,
+            yearpublished=2016,
             thumbnail="https://cf.geekdo-images.com/7SrPNGBKg9IIsP4UQpOi8g__thumb/img"
             "/gAxzddRVQiRdjZHYFUZ2xc5Jlbw=/fit-in/200x150/filters:strip_icc()/pic4325841.jpg",
             image="https://cf.geekdo-images.com/7SrPNGBKg9IIsP4UQpOi8g__original/img/GKueTbkCk2Ramf6ai8mDj-BP6cI=/0x0/"
@@ -84,6 +85,7 @@ class TestGetBoardGamesData:
             description="The ultimate test of advanced territorial strategy.",
             minplayers=2,
             maxplayers=2,
+            yearpublished=1989,
             thumbnail=None,
             image=None,
         ),
@@ -106,6 +108,7 @@ class TestGetBoardGamesData:
             description="StarWars:Rebellion is a board game of epic conflict.",
             minplayers=2,
             maxplayers=4,
+            yearpublished=2016,
             thumbnail="https://cf.geekdo-images.com/7SrPNGBKg9IIsP4UQpOi8g__thumb/img"
             "/gAxzddRVQiRdjZHYFUZ2xc5Jlbw=/fit-in/200x150/filters:strip_icc()/pic4325841.jpg",
             image="https://cf.geekdo-images.com/7SrPNGBKg9IIsP4UQpOi8g__original/img/GKueTbkCk2Ramf6ai8mDj-BP6cI=/0x0/"


### PR DESCRIPTION
Addresses the story https://github.com/JDGiardino/BGG-Companion/issues/12

Some board games have similar or the same name.  So just as BoardGameGeek does, it's useful to include the release year in the display name.  This PR grabs the release year as part of assigning values to the BoardGame data class, and pulls that value in the JavaScript when populating the random-game-response element. 