### PR TITLE
Handle BGG API response for 'request is being processed try again'

### DIFF
--- a/app.py
+++ b/app.py
@@ -51,7 +51,11 @@ def get_random_game_from_users_collection() -> Union[str, Response]:
 def get_all_games_from_users_collection() -> Union[str, Response]:
     args = request.args
     user = args.get("user")
-    bgg_companion_api = BggCompanionApi(request_client=RequestsRetryClient())
+
+    retry_codes = list(DEFAULT_HTTP_RETRY_CODES) + [202]
+    retry = make_retry_strategy(retry_codes=retry_codes)
+    bgg_companion_api = BggCompanionApi(request_client=RequestsRetryClient(retry_strategy=retry))
+
     try:
         board_games = bgg_companion_api.get_users_board_games(user)
         resp = jsonify(board_games)

--- a/app.py
+++ b/app.py
@@ -3,7 +3,11 @@ import random
 
 from src.bgg_companion_api import BggCompanionApi
 from src.exceptions import UserIsNoneError
-from src.utils.requests_retry_client import RequestsRetryClient, make_retry_strategy, DEFAULT_HTTP_RETRY_CODES
+from src.utils.requests_retry_client import (
+    RequestsRetryClient,
+    make_retry_strategy,
+    DEFAULT_HTTP_RETRY_CODES,
+)
 
 from flask import (
     Flask,

--- a/app.py
+++ b/app.py
@@ -30,11 +30,7 @@ VISIT_COUNT_COOKIE_NAME = "visit-count"
 def get_random_game_from_users_collection() -> Union[str, Response]:
     args = request.args
     user = args.get("user")
-
-    # BGG's API usually responds with a 202 and retrying gets the 200
-    retry_codes = list(DEFAULT_HTTP_RETRY_CODES) + [202]
-    retry = make_retry_strategy(retry_codes=retry_codes)
-    bgg_companion_api = BggCompanionApi(request_client=RequestsRetryClient(retry_strategy=retry))
+    bgg_companion_api = BggCompanionApi(request_client=RequestsRetryClient())
 
     try:
         filtered_board_games = bgg_companion_api.get_users_filtered_board_games(user)
@@ -51,10 +47,7 @@ def get_random_game_from_users_collection() -> Union[str, Response]:
 def get_all_games_from_users_collection() -> Union[str, Response]:
     args = request.args
     user = args.get("user")
-
-    retry_codes = list(DEFAULT_HTTP_RETRY_CODES) + [202]
-    retry = make_retry_strategy(retry_codes=retry_codes)
-    bgg_companion_api = BggCompanionApi(request_client=RequestsRetryClient(retry_strategy=retry))
+    bgg_companion_api = BggCompanionApi(request_client=RequestsRetryClient())
 
     try:
         board_games = bgg_companion_api.get_users_board_games(user)

--- a/src/bgg_companion_api.py
+++ b/src/bgg_companion_api.py
@@ -1,6 +1,6 @@
 import collections
-import random
 import xmltodict
+import time
 
 from src.models.BoardGame import BoardGame
 from src.models.GameFilter import GameFilter
@@ -18,6 +18,11 @@ class BggCompanionApi(object):
 
     def request(self, url: str):
         response = self.request_client.request(method="GET", url=url)
+        if response.text == '<?xml version="1.0" encoding="utf-8" standalone="yes"?>\n<message>\n\tYour request for ' \
+                            'this collection has been accepted and will be processed.  Please try again later for ' \
+                            'access.\n</message>':
+            time.sleep(5)
+            response = self.request_client.request(method="GET", url=url)
         return response.text
 
     @cached(cache=TTLCache(maxsize=500, ttl=300))
@@ -117,4 +122,4 @@ class BggCompanionApi(object):
 # LEAVE BELOW COMMENTED : Used for development testing
 # if __name__ == "__main__":
 #     bgg_companion_api = BggCompanionApi(request_client=RequestsRetryClient())
-#     print(bgg_companion_api.get_users_filtered_board_games("JDGiardino"))
+#     print(bgg_companion_api.get_users_filtered_board_games("Havox"))

--- a/src/bgg_companion_api.py
+++ b/src/bgg_companion_api.py
@@ -114,7 +114,7 @@ class BggCompanionApi(object):
         return filtered_board_games.filter_games()
 
 
-#LEAVE BELOW COMMENTED : Used for development testing
+# LEAVE BELOW COMMENTED : Used for development testing
 if __name__ == "__main__":
     bgg_companion_api = BggCompanionApi(request_client=RequestsRetryClient())
     print(bgg_companion_api.get_users_filtered_board_games("MeeplesOnTheGround"))

--- a/src/bgg_companion_api.py
+++ b/src/bgg_companion_api.py
@@ -18,14 +18,6 @@ class BggCompanionApi(object):
 
     def request(self, url: str):
         response = self.request_client.request(method="GET", url=url)
-        if (
-            response.text
-            == '<?xml version="1.0" encoding="utf-8" standalone="yes"?>\n<message>\n\tYour request for '
-            "this collection has been accepted and will be processed.  Please try again later for "
-            "access.\n</message>"
-        ):
-            time.sleep(5)
-            response = self.request_client.request(method="GET", url=url)
         return response.text
 
     @cached(cache=TTLCache(maxsize=500, ttl=300))
@@ -122,7 +114,7 @@ class BggCompanionApi(object):
         return filtered_board_games.filter_games()
 
 
-# LEAVE BELOW COMMENTED : Used for development testing
-# if __name__ == "__main__":
-#     bgg_companion_api = BggCompanionApi(request_client=RequestsRetryClient())
-#     print(bgg_companion_api.get_users_filtered_board_games("JDGiardino"))
+#LEAVE BELOW COMMENTED : Used for development testing
+if __name__ == "__main__":
+    bgg_companion_api = BggCompanionApi(request_client=RequestsRetryClient())
+    print(bgg_companion_api.get_users_filtered_board_games("MeeplesOnTheGround"))

--- a/src/bgg_companion_api.py
+++ b/src/bgg_companion_api.py
@@ -115,6 +115,6 @@ class BggCompanionApi(object):
 
 
 # LEAVE BELOW COMMENTED : Used for development testing
-if __name__ == "__main__":
-    bgg_companion_api = BggCompanionApi(request_client=RequestsRetryClient())
-    print(bgg_companion_api.get_users_filtered_board_games("MeeplesOnTheGround"))
+# if __name__ == "__main__":
+#     bgg_companion_api = BggCompanionApi(request_client=RequestsRetryClient())
+#     print(bgg_companion_api.get_users_filtered_board_games("JDGiardino"))

--- a/src/bgg_companion_api.py
+++ b/src/bgg_companion_api.py
@@ -123,6 +123,6 @@ class BggCompanionApi(object):
 
 
 # LEAVE BELOW COMMENTED : Used for development testing
-if __name__ == "__main__":
-    bgg_companion_api = BggCompanionApi(request_client=RequestsRetryClient())
-    print(bgg_companion_api.get_users_filtered_board_games("BoardgamingParent"))
+# if __name__ == "__main__":
+#     bgg_companion_api = BggCompanionApi(request_client=RequestsRetryClient())
+#     print(bgg_companion_api.get_users_filtered_board_games("JDGiardino"))

--- a/src/bgg_companion_api.py
+++ b/src/bgg_companion_api.py
@@ -1,6 +1,5 @@
 import collections
 import xmltodict
-import time
 
 from src.models.BoardGame import BoardGame
 from src.models.GameFilter import GameFilter

--- a/src/bgg_companion_api.py
+++ b/src/bgg_companion_api.py
@@ -18,9 +18,12 @@ class BggCompanionApi(object):
 
     def request(self, url: str):
         response = self.request_client.request(method="GET", url=url)
-        if response.text == '<?xml version="1.0" encoding="utf-8" standalone="yes"?>\n<message>\n\tYour request for ' \
-                            'this collection has been accepted and will be processed.  Please try again later for ' \
-                            'access.\n</message>':
+        if (
+            response.text
+            == '<?xml version="1.0" encoding="utf-8" standalone="yes"?>\n<message>\n\tYour request for '
+            "this collection has been accepted and will be processed.  Please try again later for "
+            "access.\n</message>"
+        ):
             time.sleep(5)
             response = self.request_client.request(method="GET", url=url)
         return response.text
@@ -120,6 +123,6 @@ class BggCompanionApi(object):
 
 
 # LEAVE BELOW COMMENTED : Used for development testing
-# if __name__ == "__main__":
-#     bgg_companion_api = BggCompanionApi(request_client=RequestsRetryClient())
-#     print(bgg_companion_api.get_users_filtered_board_games("Havox"))
+if __name__ == "__main__":
+    bgg_companion_api = BggCompanionApi(request_client=RequestsRetryClient())
+    print(bgg_companion_api.get_users_filtered_board_games("BoardgamingParent"))

--- a/src/utils/requests_retry_client.py
+++ b/src/utils/requests_retry_client.py
@@ -27,6 +27,10 @@ DEFAULT_HTTP_RETRY_CODES: tuple[int, ...] = (
     511,  # network auth
 )
 
+BGG_API_HTTP_RETRY_CODES: tuple[int, ...] = (
+    202,  # BGG's API response always returns a 202 asking to please try again later for access
+)
+
 
 def make_retry_strategy(
     backoff_factor: Optional[int] = None,
@@ -39,7 +43,7 @@ def make_retry_strategy(
     if not backoff_factor:
         backoff_factor = 3
     if not retry_codes:
-        retry_codes = list(DEFAULT_HTTP_RETRY_CODES)
+        retry_codes = list(DEFAULT_HTTP_RETRY_CODES + BGG_API_HTTP_RETRY_CODES)
     if not methods:
         methods = list(DEFAULT_HTTP_METHODS)
 


### PR DESCRIPTION
This is to address the bug https://github.com/JDGiardino/BGG-Companion/issues/22. 

As the bug ticket states, this addresses when an API request is made to BoardGameGeek for the first time the response message states "Your request for this collection has been accepted and will be processed. Please try again later for access" and actually requires a second request.  

I tested on a ton of users and it seems like the processing happening takes longer the larger the user's collection is.  Which is why we sleep for 5 seconds before retrying.  Although maybe this is too long and could get away with a shorter wait time. 