### PR TITLE
Revert "Add docker file to run build process in digital ocean."

### DIFF
--- a/DockerFIle
+++ b/DockerFIle
@@ -1,8 +1,0 @@
-# syntax=docker/dockerfile:1
-FROM node:16
-WORKDIR /front-end/
-RUN npm install
-RUN npm run build
-WORKDIR /
-RUN mkdir /FEProdBuild
-COPY /frontend/build /FEProdBuild


### PR DESCRIPTION
Reverts JDGiardino/BGG-Companion#59 because i misspelled the docker file. Not entirely sure if spelling doesn't matter, since I was unable to rename the file. Git would not see the difference and i was unable to commit the rename. There is a possibility that it didn't work but will need to retry with correct spelling and verify. 