### PR TITLE
Include a games rating, complexity level, and rank to the BoardGame class

### DIFF
--- a/src/bgg_companion_api.py
+++ b/src/bgg_companion_api.py
@@ -1,5 +1,4 @@
 import collections
-import random
 import xmltodict
 
 from src.models.BoardGame import BoardGame
@@ -38,7 +37,7 @@ class BggCompanionApi(object):
 
     @cached(cache=TTLCache(maxsize=500, ttl=300))
     def get_board_games(self, ids: tuple[str]) -> list[BoardGame]:
-        string_xml = self.request(f'https://api.geekdo.com/xmlapi2/thing?id={",".join(ids)}')
+        string_xml = self.request(f'https://api.geekdo.com/xmlapi2/thing?id={",".join(ids)}&stats=1')
         xml_parse = xmltodict.parse(string_xml)
         if "item" not in xml_parse["items"]:
             raise BoardGameIsNoneError(
@@ -64,12 +63,21 @@ class BggCompanionApi(object):
         minplayers = item["minplayers"]["@value"]
         maxplayers = item["maxplayers"]["@value"]
         yearpublished = item["yearpublished"]["@value"]
+        averagerating = item["statistics"]["ratings"]["average"]["@value"]
+        complexity = item["statistics"]["ratings"]["averageweight"]["@value"]
         if "thumbnail" in item and "image" in item:
             thumbnail = item["thumbnail"]
             image = item["image"]
         else:
             thumbnail = None
             image = None
+        if isinstance(item["statistics"]["ratings"]["ranks"]["rank"], OrderedDict):
+            overallrank = item["statistics"]["ratings"]["ranks"]["rank"]["@value"]
+        elif isinstance(item["statistics"]["ratings"]["ranks"]["rank"], list):
+            for a_dict in item["statistics"]["ratings"]["ranks"]["rank"]:
+                if a_dict["@type"] == "subtype":
+                    overallrank = a_dict["@value"]
+                    break
         if isinstance(item["name"], OrderedDict):
             name = item["name"]["@value"]
         elif isinstance(item["name"], list):
@@ -87,6 +95,9 @@ class BggCompanionApi(object):
             minplayers=minplayers,
             maxplayers=maxplayers,
             yearpublished=yearpublished,
+            averagerating=averagerating,
+            complexity=complexity,
+            overallrank=overallrank,
             thumbnail=thumbnail,
             image=image,
         )
@@ -115,6 +126,6 @@ class BggCompanionApi(object):
 
 
 # LEAVE BELOW COMMENTED : Used for development testing
-# if __name__ == "__main__":
-#     bgg_companion_api = BggCompanionApi(request_client=RequestsRetryClient())
-#     print(bgg_companion_api.get_users_filtered_board_games("JDGiardino"))
+if __name__ == "__main__":
+    bgg_companion_api = BggCompanionApi(request_client=RequestsRetryClient())
+    print(bgg_companion_api.get_users_filtered_board_games("JDGiardino"))

--- a/src/bgg_companion_api.py
+++ b/src/bgg_companion_api.py
@@ -37,7 +37,9 @@ class BggCompanionApi(object):
 
     @cached(cache=TTLCache(maxsize=500, ttl=300))
     def get_board_games(self, ids: tuple[str]) -> list[BoardGame]:
-        string_xml = self.request(f'https://api.geekdo.com/xmlapi2/thing?id={",".join(ids)}&stats=1')
+        string_xml = self.request(
+            f'https://api.geekdo.com/xmlapi2/thing?id={",".join(ids)}&stats=1'
+        )
         xml_parse = xmltodict.parse(string_xml)
         if "item" not in xml_parse["items"]:
             raise BoardGameIsNoneError(
@@ -126,6 +128,6 @@ class BggCompanionApi(object):
 
 
 # LEAVE BELOW COMMENTED : Used for development testing
-if __name__ == "__main__":
-    bgg_companion_api = BggCompanionApi(request_client=RequestsRetryClient())
-    print(bgg_companion_api.get_users_filtered_board_games("JDGiardino"))
+# if __name__ == "__main__":
+#     bgg_companion_api = BggCompanionApi(request_client=RequestsRetryClient())
+#     print(bgg_companion_api.get_users_filtered_board_games("JDGiardino"))

--- a/src/models/BoardGame.py
+++ b/src/models/BoardGame.py
@@ -11,6 +11,9 @@ class BoardGame:
     minplayers: int
     maxplayers: int
     yearpublished: int
+    averagerating: float
+    complexity: float
+    overallrank: Optional[float] = None
     thumbnail: Optional[str] = None
     image: Optional[str] = None
 
@@ -19,4 +22,10 @@ class BoardGame:
         object.__setattr__(self, "maxplayers", int(self.maxplayers))
         object.__setattr__(self, "minplayers", int(self.minplayers))
         object.__setattr__(self, "yearpublished", int(self.yearpublished))
+        object.__setattr__(self, "averagerating", float(self.averagerating))
+        object.__setattr__(self, "complexity", float(self.complexity))
+        if self.overallrank == "Not Ranked":
+            object.__setattr__(self, "overallrank", str(self.overallrank))
+        else:
+            object.__setattr__(self, "overallrank", float(self.overallrank))
         # This bypasses frozen=true by modifying the object class which all objects inherent from including dataclasses

--- a/tests/models/TestBggCompanionData.py
+++ b/tests/models/TestBggCompanionData.py
@@ -66,7 +66,7 @@ class TestGetBoardGamesData:
         'The ultimate test of advanced territorial strategy.</description><yearpublished value="1989"/>'
         '<minplayers value="2"/><maxplayers value="2"/><statistics page="1"><ratings><average value="5.63488" /><ranks>'
         ' <rank type="subtype" id="1" name="boardgame" value="17645"/></ranks><averageweight value="1.625"/>'
-        ' </ratings></statistics></item></items>'
+        " </ratings></statistics></item></items>"
     )
     expected_two_ids = [
         BoardGame(
@@ -81,9 +81,9 @@ class TestGetBoardGamesData:
             complexity=3.733,
             overallrank=8,
             thumbnail="https://cf.geekdo-images.com/7SrPNGBKg9IIsP4UQpOi8g__thumb/img"
-                      "/gAxzddRVQiRdjZHYFUZ2xc5Jlbw=/fit-in/200x150/filters:strip_icc()/pic4325841.jpg",
+            "/gAxzddRVQiRdjZHYFUZ2xc5Jlbw=/fit-in/200x150/filters:strip_icc()/pic4325841.jpg",
             image="https://cf.geekdo-images.com/7SrPNGBKg9IIsP4UQpOi8g__original/img/GKueTbkCk2Ramf6ai8mDj-BP6cI=/0x0/"
-                  "filters:format(jpeg)/pic4325841.jpg",
+            "filters:format(jpeg)/pic4325841.jpg",
         ),
         BoardGame(
             id=6902,
@@ -124,9 +124,9 @@ class TestGetBoardGamesData:
             complexity=3.733,
             overallrank=8,
             thumbnail="https://cf.geekdo-images.com/7SrPNGBKg9IIsP4UQpOi8g__thumb/img"
-                      "/gAxzddRVQiRdjZHYFUZ2xc5Jlbw=/fit-in/200x150/filters:strip_icc()/pic4325841.jpg",
+            "/gAxzddRVQiRdjZHYFUZ2xc5Jlbw=/fit-in/200x150/filters:strip_icc()/pic4325841.jpg",
             image="https://cf.geekdo-images.com/7SrPNGBKg9IIsP4UQpOi8g__original/img/GKueTbkCk2Ramf6ai8mDj-BP6cI=/0x0/"
-                  "filters:format(jpeg)/pic4325841.jpg",
+            "filters:format(jpeg)/pic4325841.jpg",
         )
     ]
     invalid_id_response = '<?xml version="1.0" encoding="utf-8"?><items termsofuse="https://boardgamegeek.com/xmlapi/termsofuse"></items>'

--- a/tests/models/TestBggCompanionData.py
+++ b/tests/models/TestBggCompanionData.py
@@ -59,10 +59,14 @@ class TestGetBoardGamesData:
         "https://cf.geekdo-images.com/7SrPNGBKg9IIsP4UQpOi8g__original/img/GKueTbkCk2Ramf6ai8mDj-BP6cI=/0x0/filters:"
         'format(jpeg)/pic4325841.jpg</image><name type = "primary" sortindex = "1" value = "Star Wars: Rebellion"/>'
         '<name type="alternate" sortindex="1" value="Star Wars: Lázadás"/><description>StarWars:Rebellion is a board game'
-        ' of epic conflict.</description><yearpublished value="2016"/><minplayers value="2"/><maxplayers value="4"/></item>'
+        ' of epic conflict.</description><yearpublished value="2016"/><minplayers value="2"/><maxplayers value="4"/>'
+        ' <statistics page="1"><ratings><average value="8.41956"/><ranks><rank type="subtype" id="1" name="boardgame" value="8"/>'
+        ' </ranks><averageweight value="3.733" /></ratings></statistics></item>'
         '<item type="boardgame" id="6902"><name type="primary" sortindex="1" value="Tetris"/><description>'
         'The ultimate test of advanced territorial strategy.</description><yearpublished value="1989"/>'
-        '<minplayers value="2"/><maxplayers value="2"/></item></items>'
+        '<minplayers value="2"/><maxplayers value="2"/><statistics page="1"><ratings><average value="5.63488" /><ranks>'
+        ' <rank type="subtype" id="1" name="boardgame" value="17645"/></ranks><averageweight value="1.625"/>'
+        ' </ratings></statistics></item></items>'
     )
     expected_two_ids = [
         BoardGame(
@@ -73,10 +77,13 @@ class TestGetBoardGamesData:
             minplayers=2,
             maxplayers=4,
             yearpublished=2016,
+            averagerating=8.41956,
+            complexity=3.733,
+            overallrank=8,
             thumbnail="https://cf.geekdo-images.com/7SrPNGBKg9IIsP4UQpOi8g__thumb/img"
-            "/gAxzddRVQiRdjZHYFUZ2xc5Jlbw=/fit-in/200x150/filters:strip_icc()/pic4325841.jpg",
+                      "/gAxzddRVQiRdjZHYFUZ2xc5Jlbw=/fit-in/200x150/filters:strip_icc()/pic4325841.jpg",
             image="https://cf.geekdo-images.com/7SrPNGBKg9IIsP4UQpOi8g__original/img/GKueTbkCk2Ramf6ai8mDj-BP6cI=/0x0/"
-            "filters:format(jpeg)/pic4325841.jpg",
+                  "filters:format(jpeg)/pic4325841.jpg",
         ),
         BoardGame(
             id=6902,
@@ -86,6 +93,9 @@ class TestGetBoardGamesData:
             minplayers=2,
             maxplayers=2,
             yearpublished=1989,
+            averagerating=5.63488,
+            complexity=1.625,
+            overallrank=17645,
             thumbnail=None,
             image=None,
         ),
@@ -97,8 +107,9 @@ class TestGetBoardGamesData:
         "https://cf.geekdo-images.com/7SrPNGBKg9IIsP4UQpOi8g__original/img/GKueTbkCk2Ramf6ai8mDj-BP6cI=/0x0/filters:"
         'format(jpeg)/pic4325841.jpg</image><name type = "primary" sortindex = "1" value = "Star Wars: Rebellion"/>'
         '<name type="alternate" sortindex="1" value="Star Wars: Lázadás"/><description>StarWars:Rebellion is a board game'
-        ' of epic conflict.</description><yearpublished value="2016"/><minplayers value="2"/><maxplayers value="4"/></item>'
-        "</items>"
+        ' of epic conflict.</description><yearpublished value="2016"/><minplayers value="2"/><maxplayers value="4"/>'
+        ' <statistics page="1"><ratings><average value="8.41956"/><ranks><rank type="subtype" id="1" name="boardgame" value="8"/>'
+        ' </ranks><averageweight value="3.733" /></ratings></statistics></item></items>'
     )
     expected_one_id = [
         BoardGame(
@@ -109,10 +120,13 @@ class TestGetBoardGamesData:
             minplayers=2,
             maxplayers=4,
             yearpublished=2016,
+            averagerating=8.41956,
+            complexity=3.733,
+            overallrank=8,
             thumbnail="https://cf.geekdo-images.com/7SrPNGBKg9IIsP4UQpOi8g__thumb/img"
-            "/gAxzddRVQiRdjZHYFUZ2xc5Jlbw=/fit-in/200x150/filters:strip_icc()/pic4325841.jpg",
+                      "/gAxzddRVQiRdjZHYFUZ2xc5Jlbw=/fit-in/200x150/filters:strip_icc()/pic4325841.jpg",
             image="https://cf.geekdo-images.com/7SrPNGBKg9IIsP4UQpOi8g__original/img/GKueTbkCk2Ramf6ai8mDj-BP6cI=/0x0/"
-            "filters:format(jpeg)/pic4325841.jpg",
+                  "filters:format(jpeg)/pic4325841.jpg",
         )
     ]
     invalid_id_response = '<?xml version="1.0" encoding="utf-8"?><items termsofuse="https://boardgamegeek.com/xmlapi/termsofuse"></items>'


### PR DESCRIPTION
In order to accomplish https://github.com/JDGiardino/BGG-Companion/issues/30, we'll need to include things like a game's rank in the BoardGame object.  We haven't been including this data yet as the API call requires an extra parameter to get that data.

Including the data for a game's overall rating on BoardGameGeek, the game's complexity level, and a game's average rating as these all can be similarly as https://github.com/JDGiardino/BGG-Companion/issues/30.  